### PR TITLE
Feature - 436 integrate api to accept reject modal

### DIFF
--- a/src/components/projects/ApplicationsModal/ApplicationAPI.js
+++ b/src/components/projects/ApplicationsModal/ApplicationAPI.js
@@ -1,0 +1,28 @@
+import { alertError } from "../../../store/actions/alertActions";
+import axios from "axios";
+import store from "../../../store";
+
+const API_HOST_PROJECTS = process.env.REACT_APP_API_PROJECTS_URL;
+const API_NAME = "projects";
+const API_VERSION = "v1";
+
+export async function updateProject(projectId, idResume, name) {
+  let project = [];
+  const patch = [
+    {
+      op: "add",
+      path: "/MemberList/-",
+      value: { idResume, name },
+    },
+  ];
+  try {
+    const { data } = await axios.patch(
+      `${API_HOST_PROJECTS}/api/${API_VERSION}/${API_NAME}/${projectId}`,
+      patch
+    );
+    project = data;
+    return project;
+  } catch (error) {
+    store.dispatch(alertError(error.message));
+  }
+}

--- a/src/components/projects/ApplicationsModal/ApplicationAPI.js
+++ b/src/components/projects/ApplicationsModal/ApplicationAPI.js
@@ -3,11 +3,12 @@ import axios from "axios";
 import store from "../../../store";
 
 const API_HOST_PROJECTS = process.env.REACT_APP_API_PROJECTS_URL;
-const API_NAME = "projects";
+const API_HOST_RESUMES = process.env.REACT_APP_API_RESUMES_URL;
+const API_NAME_PROJECTS = "projects";
+const API_NAME_POSTULATIONS = "postulations";
 const API_VERSION = "v1";
 
 export async function updateProject(projectId, idResume, name) {
-  let project = [];
   const patch = [
     {
       op: "add",
@@ -16,12 +17,28 @@ export async function updateProject(projectId, idResume, name) {
     },
   ];
   try {
-    const { data } = await axios.patch(
-      `${API_HOST_PROJECTS}/api/${API_VERSION}/${API_NAME}/${projectId}`,
+    await axios.patch(
+      `${API_HOST_PROJECTS}/api/${API_VERSION}/${API_NAME_PROJECTS}/${projectId}`,
       patch
     );
-    project = data;
-    return project;
+  } catch (error) {
+    store.dispatch(alertError(error.message));
+  }
+}
+
+export async function updatePostulation(postulationId, state) {
+  const patch = [
+    {
+      op: "replace",
+      path: "/State",
+      value: state,
+    },
+  ];
+  try {
+    await axios.patch(
+      `${API_HOST_RESUMES}/api/${API_VERSION}/${API_NAME_POSTULATIONS}/${postulationId}`,
+      patch
+    );
   } catch (error) {
     store.dispatch(alertError(error.message));
   }

--- a/src/components/projects/ApplicationsModal/ApplicationsModal.jsx
+++ b/src/components/projects/ApplicationsModal/ApplicationsModal.jsx
@@ -7,9 +7,9 @@ import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import MuiAccordion from "@material-ui/core/Accordion";
 import MuiAccordionDetails from "@material-ui/core/AccordionDetails";
 import MuiAccordionSummary from "@material-ui/core/AccordionSummary";
-import { updateProject } from "./ApplicationAPI";
 import { Dialog, DialogContent, List, Typography } from "@material-ui/core";
 import { makeStyles, withStyles } from "@material-ui/core/styles";
+import { updatePostulation, updateProject } from "./ApplicationAPI";
 import "./ApplicationsModal.scss";
 
 const Accordion = withStyles({
@@ -76,8 +76,14 @@ const useStyles = makeStyles((theme) => ({
 function ApplicationsModal({ onClickModal, open, postulations, projectId }) {
   const classes = useStyles();
 
-  async function handleAccept(projectId, resumeID, resumeName) {
+  async function handleAccept(projectId, resumeID, resumeName, postulationId) {
+    await updatePostulation(postulationId, "Accepted");
     await updateProject(projectId, resumeID, resumeName);
+    onClickModal();
+  }
+
+  async function handleReject(postulationId) {
+    await updatePostulation(postulationId, "Rejected");
     onClickModal();
   }
 
@@ -124,7 +130,8 @@ function ApplicationsModal({ onClickModal, open, postulations, projectId }) {
                               handleAccept(
                                 projectId,
                                 postulation.resumeId,
-                                postulation.resumeName
+                                postulation.resumeName,
+                                postulation.id
                               )
                             }
                             style={{ fontSize: "10px", marginLeft: "40%" }}
@@ -134,6 +141,7 @@ function ApplicationsModal({ onClickModal, open, postulations, projectId }) {
                           </Button>
                           <Button
                             color="secondary"
+                            onClick={() => handleReject(postulation.id)}
                             style={{ fontSize: "10px", marginLeft: "10%" }}
                             variant="outlined"
                           >

--- a/src/components/projects/ApplicationsModal/ApplicationsModal.jsx
+++ b/src/components/projects/ApplicationsModal/ApplicationsModal.jsx
@@ -7,6 +7,7 @@ import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import MuiAccordion from "@material-ui/core/Accordion";
 import MuiAccordionDetails from "@material-ui/core/AccordionDetails";
 import MuiAccordionSummary from "@material-ui/core/AccordionSummary";
+import { updateProject } from "./ApplicationAPI";
 import { Dialog, DialogContent, List, Typography } from "@material-ui/core";
 import { makeStyles, withStyles } from "@material-ui/core/styles";
 import "./ApplicationsModal.scss";
@@ -72,8 +73,14 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-function ApplicationsModal({ onClickModal, open, postulations }) {
+function ApplicationsModal({ onClickModal, open, postulations, projectId }) {
   const classes = useStyles();
+
+  async function handleAccept(projectId, resumeID, resumeName) {
+    await updateProject(projectId, resumeID, resumeName);
+    onClickModal();
+  }
+
   return (
     <div>
       <Dialog onClose={onClickModal} open={open}>
@@ -113,6 +120,13 @@ function ApplicationsModal({ onClickModal, open, postulations }) {
                         <div style={{ display: "flex", marginBottom: "3%" }}>
                           <Button
                             color="primary"
+                            onClick={() =>
+                              handleAccept(
+                                projectId,
+                                postulation.resumeId,
+                                postulation.resumeName
+                              )
+                            }
                             style={{ fontSize: "10px", marginLeft: "40%" }}
                             variant="outlined"
                           >

--- a/src/components/projects/Details.jsx
+++ b/src/components/projects/Details.jsx
@@ -101,6 +101,7 @@ function Details() {
           onClickModal={handleActionModal}
           open={open}
           postulations={postulations}
+          projectId={id}
         />
 
         <div className="box-details">


### PR DESCRIPTION
[AB#436](https://dev.azure.com/funjaladev/DevLevel3/_sprints/backlog/DevLevel3%20Team/DevLevel3/Sprint%208%20-%20Final?workitem=436)

# Overview

Integrate API to Accept or Reject Modal

## Outstanding Tasks
Accept: Should display on projects details that resume on the member list (patch to project)
Accept: Should display on resumes detail, section: Your applications (patch to postulation, state: accepted) 
Reject: Should display on resumes detail, section: Your applications (patch to postulation, state: rejected) 
